### PR TITLE
removed bulkSetItems from public interface because the use case would…

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,7 +8,17 @@ parameters:
             # ignored because it's intentionally not specified
             message: '#.+no value type specified in iterable type array.+#'
             path: src\KeyToValueArray.php
-            count: 3
+            count: 4
+        -
+           # ignored because it's intentionally not specified
+           message: '#.+no value type specified in iterable type array.+#'
+           path: tests\IntToValueArrays\IntToClassArrayTest.php
+           count: 2
+        -
+           # ignored because it's intentionally not specified
+           message: '#.+no value type specified in iterable type array.+#'
+           path: tests\StringToValueArrays\StringToClassArrayTest.php
+           count: 2
         -
             # ignored because generics seem too complex to look into at the moment
             message: '#.+implements generic interface.+but does not specify its types.+#'

--- a/src/KeyToValueArray.php
+++ b/src/KeyToValueArray.php
@@ -14,11 +14,15 @@ abstract class KeyToValueArray implements \Iterator, \Countable, \ArrayAccess
 
     protected IValidate $valueValidator;
 
-    public function __construct()
+    public function __construct(array $array = null)
     {
         $this->keyValidator = $this->getKeyValidator();
 
         $this->valueValidator = $this->getValueValidator();
+
+        if ($array !== null) {
+            $this->bulkSetItems($array);
+        }
     }
 
     public function getItems(): array
@@ -106,7 +110,7 @@ abstract class KeyToValueArray implements \Iterator, \Countable, \ArrayAccess
      *
      * @psalm-suppress MixedAssignment //The type of $value needs to be ambiguous here
      */
-    public function bulkSetItems(array $array): void
+    protected function bulkSetItems(array $array): void
     {
         foreach ($array as $key => $value){
             $this->validateKey($key);

--- a/src/KeyToValueArray.php
+++ b/src/KeyToValueArray.php
@@ -14,6 +14,10 @@ abstract class KeyToValueArray implements \Iterator, \Countable, \ArrayAccess
 
     protected IValidate $valueValidator;
 
+    /**
+     * @param array|null $array
+     * @throws \InvalidArgumentException
+     */
     public function __construct(array $array = null)
     {
         $this->keyValidator = $this->getKeyValidator();

--- a/tests/IntToValueArrays/IntToClassArrayTest.php
+++ b/tests/IntToValueArrays/IntToClassArrayTest.php
@@ -27,21 +27,27 @@ final class IntToClassArrayTest extends TestCase
 
         $this->fullyQualifiedClassName = IntToClassArray::class;
 
-        $this->permittedClassObject = TestHelpers::generateAnonClassObject();
+        $this->permittedClassObject = TestHelpers::newEmptyClassObject();
 
         $this->permittedClass = get_class($this->permittedClassObject);
 
-        //This sets the className property on construction only for testing purposes
-        //A genuine extending class of IntToClassArray would rightly have this hardcoded
-        $this->extendsTypedArray = new class($this->permittedClass) extends IntToClassArray
+
+        $this->extendsTypedArray = $this->newExtendingClassObject($this->permittedClass);
+    }
+
+    //This sets the className property on construction only for testing purposes
+    //A genuine extending class of IntToClassArray would rightly have this hardcoded
+    protected function newExtendingClassObject(string $permittedClass, array $array = null): IntToClassArray
+    {
+        return new class($permittedClass, $array) extends IntToClassArray
         {
             protected string $className;
 
-            public function __construct(string $className)
+            public function __construct(string $className, array $array = null)
             {
                 $this->className = $className;
 
-                parent::__construct();
+                parent::__construct($array);
             }
 
             /**
@@ -97,35 +103,35 @@ final class IntToClassArrayTest extends TestCase
         );
     }
 
-    //bulkSetItems:
-    public function testBulkSetItems(): void
+    //bulkSetItems on construct:
+    public function testConstructorBulkSetItems(): void
     {
-        $secondPermittedClassObject = TestHelpers::generateAnonClassObject();
+        $secondPermittedClassObject = TestHelpers::newEmptyClassObject();
 
         $array = [
             0 => $this->permittedClassObject,
             1 => $secondPermittedClassObject
         ];
 
-        $this->extendsTypedArray->bulkSetItems($array);
+        $extendsTypedArray = $this->newExtendingClassObject($this->permittedClass, $array);
 
         $this::assertSame(
             $array,
-            $this->extendsTypedArray->getItems()
+            $extendsTypedArray->getItems()
         );
     }
 
-    public function testBulkSetItemsParamIsTypeArray(): void
+    public function testArrayParamIsTypeArray(): void
     {
         $this::assertSame(
             'array',
-            TestHelpers::getParameterType($this->fullyQualifiedClassName, 'bulkSetItems', 'array', $this)
+            TestHelpers::getParameterType($this->fullyQualifiedClassName, '__construct', 'array', $this)
         );
     }
 
-    public function testBulkSetItemsKeyError(): void
+    public function testConstructorArrayKeyError(): void
     {
-        $secondPermittedClassObject = TestHelpers::generateAnonClassObject();
+        $secondPermittedClassObject = TestHelpers::newEmptyClassObject();
 
         $array = [
             0 => $this->permittedClassObject,
@@ -134,10 +140,10 @@ final class IntToClassArrayTest extends TestCase
 
         $this::expectException(\InvalidArgumentException::class);
 
-        $this->extendsTypedArray->bulkSetItems($array);
+        $this->newExtendingClassObject($this->permittedClass, $array);
     }
 
-    public function testBulkSetItemsClassError(): void
+    public function testConstructorArrayClassError(): void
     {
         $array = [
             0 => $this->permittedClassObject,
@@ -146,12 +152,12 @@ final class IntToClassArrayTest extends TestCase
 
         $this::expectException(\InvalidArgumentException::class);
 
-        $this->extendsTypedArray->bulkSetItems($array);
+        $this->newExtendingClassObject($this->permittedClass, $array);
     }
 
-    public function testBulkSetItemsValueError(): void
+    public function testConstructorArrayValueError(): void
     {
-        $secondPermittedClassObject = TestHelpers::generateAnonClassObject();
+        $secondPermittedClassObject = TestHelpers::newEmptyClassObject();
 
         $array = [
             0 => $this->permittedClassObject,
@@ -162,7 +168,7 @@ final class IntToClassArrayTest extends TestCase
 
         $this::expectException(\InvalidArgumentException::class);
 
-        $this->extendsTypedArray->bulkSetItems($array);
+        $this->newExtendingClassObject($this->permittedClass, $array);
     }
 
     //unsetItem:
@@ -171,7 +177,7 @@ final class IntToClassArrayTest extends TestCase
     {
         $this->extendsTypedArray->setItem(0, $this->permittedClassObject);
 
-        $secondPermittedClassObject = TestHelpers::generateAnonClassObject();
+        $secondPermittedClassObject = TestHelpers::newEmptyClassObject();
 
         $this->extendsTypedArray->setItem(1, $secondPermittedClassObject);
 
@@ -283,7 +289,7 @@ final class IntToClassArrayTest extends TestCase
     {
         $this->extendsTypedArray->setItem(0, $this->permittedClassObject);
 
-        $secondPermittedClassObject = TestHelpers::generateAnonClassObject();
+        $secondPermittedClassObject = TestHelpers::newEmptyClassObject();
 
         $this->extendsTypedArray->setItem(1, $secondPermittedClassObject);
 

--- a/tests/IntToValueArrays/IntToIntArrayTest.php
+++ b/tests/IntToValueArrays/IntToIntArrayTest.php
@@ -92,7 +92,7 @@ final class IntToIntArrayTest extends TestCase
         new IntToIntArray($array);
     }
 
-    public function testBulkSetItemsValueError(): void
+    public function testConstructorArrayValueError(): void
     {
         $array = [
             0 => 0,

--- a/tests/IntToValueArrays/IntToIntArrayTest.php
+++ b/tests/IntToValueArrays/IntToIntArrayTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection PhpExpressionResultUnusedInspection */
 
 declare(strict_types = 1);
 
@@ -56,31 +56,31 @@ final class IntToIntArrayTest extends TestCase
         );
     }
 
-    //bulkSetItems:
-    public function testBulkSetItems(): void
+    //bulkSetItems on construct:
+    public function testConstructorBulkSetItems(): void
     {
         $array = [
             0 => 0,
             1 => 1
         ];
 
-        $this->array->bulkSetItems($array);
+        $newTypedArray = new IntToIntArray($array);
 
         $this::assertSame(
             $array,
-            $this->array->getItems()
+            $newTypedArray->getItems()
         );
     }
 
-    public function testBulkSetItemsParamIsTypeArray(): void
+    public function testArrayParamIsTypeArray(): void
     {
         $this::assertSame(
             'array',
-            TestHelpers::getParameterType($this->fullyQualifiedClassName, 'bulkSetItems', 'array', $this)
+            TestHelpers::getParameterType($this->fullyQualifiedClassName, '__construct', 'array', $this)
         );
     }
 
-    public function testBulkSetItemsKeyError(): void
+    public function testConstructorArrayKeyError(): void
     {
         $array = [
             0 => 0,
@@ -89,7 +89,7 @@ final class IntToIntArrayTest extends TestCase
 
         $this::expectException(\InvalidArgumentException::class);
 
-        $this->array->bulkSetItems($array);
+        new IntToIntArray($array);
     }
 
     public function testBulkSetItemsValueError(): void
@@ -103,7 +103,7 @@ final class IntToIntArrayTest extends TestCase
 
         $this::expectException(\InvalidArgumentException::class);
 
-        $this->array->bulkSetItems($array);
+        new IntToIntArray($array);
     }
 
     //unsetItem:

--- a/tests/IntToValueArrays/IntToStringArrayTest.php
+++ b/tests/IntToValueArrays/IntToStringArrayTest.php
@@ -99,7 +99,7 @@ final class IntToStringArrayTest extends TestCase
         new IntToStringArray($array);
     }
 
-    public function testBulkSetItemsValueError(): void
+    public function testConstructorArrayValueError(): void
     {
         $array = [
             0 => 'a',

--- a/tests/IntToValueArrays/IntToStringArrayTest.php
+++ b/tests/IntToValueArrays/IntToStringArrayTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection PhpExpressionResultUnusedInspection */
 
 declare(strict_types = 1);
 
@@ -63,31 +63,31 @@ final class IntToStringArrayTest extends TestCase
         );
     }
 
-    //bulkSetItems:
-    public function testBulkSetItems(): void
+    //bulkSetItems on construct:
+    public function testConstructorBulkSetItems(): void
     {
         $array = [
             0 => 'a',
             1 => 'b'
         ];
 
-        $this->array->bulkSetItems($array);
+        $newTypedArray = new IntToStringArray($array);
 
         $this::assertSame(
             $array,
-            $this->array->getItems()
+            $newTypedArray->getItems()
         );
     }
 
-    public function testBulkSetItemsParamIsTypeArray(): void
+    public function testArrayParamIsTypeArray(): void
     {
         $this::assertSame(
             'array',
-            TestHelpers::getParameterType($this->fullyQualifiedClassName, 'bulkSetItems', 'array', $this)
+            TestHelpers::getParameterType($this->fullyQualifiedClassName, '__construct', 'array', $this)
         );
     }
 
-    public function testBulkSetItemsKeyError(): void
+    public function testConstructorArrayKeyError(): void
     {
         $array = [
             0 => 'a',
@@ -96,7 +96,7 @@ final class IntToStringArrayTest extends TestCase
 
         $this::expectException(\InvalidArgumentException::class);
 
-        $this->array->bulkSetItems($array);
+        new IntToStringArray($array);
     }
 
     public function testBulkSetItemsValueError(): void
@@ -110,7 +110,7 @@ final class IntToStringArrayTest extends TestCase
 
         $this::expectException(\InvalidArgumentException::class);
 
-        $this->array->bulkSetItems($array);
+        new IntToStringArray($array);
     }
 
     //unsetItem:

--- a/tests/StringToValueArrays/StringToClassArrayTest.php
+++ b/tests/StringToValueArrays/StringToClassArrayTest.php
@@ -27,36 +27,42 @@ final class StringToClassArrayTest extends TestCase
 
         $this->fullyQualifiedClassName = StringToClassArray::class;
 
-        $this->permittedClassObject = TestHelpers::generateAnonClassObject();
+        $this->permittedClassObject = TestHelpers::newEmptyClassObject();
 
         $this->permittedClass = get_class($this->permittedClassObject);
 
-        //This sets the className property on construction only for testing purposes
-        //A genuine extending class of StringToClassArray would rightly have this hardcoded
-        $this->extendsTypedArray = new class($this->permittedClass) extends StringToClassArray
+        $this->extendsTypedArray = $this->newExtendingClassObject($this->permittedClass);
+    }
+
+    //This sets the className property on construction only for testing purposes
+    //A genuine extending class of StringToClassArray would rightly have this hardcoded
+    protected function newExtendingClassObject(string $permittedClass, array $array = null): StringToClassArray
+    {
+        return new class($permittedClass, $array) extends StringToClassArray
+        {
+            protected string $className;
+
+            public function __construct(string $className, array $array = null)
             {
-                protected string $className;
+                $this->className = $className;
 
-                public function __construct(string $className)
-                {
-                    $this->className = $className;
+                parent::__construct($array);
+            }
 
-                    parent::__construct();
-                }
-
-                /**
-                 * @return class-string
-                 *
-                 * It's not possible to generate a class-string from an anonymous class:
-                 * @psalm-suppress MoreSpecificReturnType
-                 * @psalm-suppress LessSpecificReturnStatement
-                 */
-                protected function getClassName(): string
-                {
-                    /** @phpstan-ignore-next-line */
-                    return $this->className;
-                }
-            };
+            /**
+             * @return class-string
+             *
+             * It's not possible to generate a class-string from an anonymous class:
+             * @psalm-suppress MoreSpecificReturnType
+             * @psalm-suppress LessSpecificReturnStatement
+             * @
+             */
+            protected function getClassName(): string
+            {
+                /** @phpstan-ignore-next-line */
+                return $this->className;
+            }
+        };
     }
 
     //setItem & getItems:
@@ -111,36 +117,36 @@ final class StringToClassArrayTest extends TestCase
         );
     }
 
-    //bulkSetItems:
+    //bulkSetItemson construct:
     //no need to test for numeric string key casting, as numeric strings will have already been int cast in the array
-    public function testBulkSetItems(): void
+    public function testConstructorBulkSetItems(): void
     {
-        $secondPermittedClassObject = TestHelpers::generateAnonClassObject();
+        $secondPermittedClassObject = TestHelpers::newEmptyClassObject();
 
         $array = [
             'a' => $this->permittedClassObject,
             'b' => $secondPermittedClassObject
         ];
 
-        $this->extendsTypedArray->bulkSetItems($array);
+        $extendsTypedArray = $this->newExtendingClassObject($this->permittedClass, $array);
 
         $this::assertSame(
             $array,
-            $this->extendsTypedArray->getItems()
+            $extendsTypedArray->getItems()
         );
     }
 
-    public function testBulkSetItemsParamIsTypeArray(): void
+    public function testArrayParamIsTypeArray(): void
     {
         $this::assertSame(
             'array',
-            TestHelpers::getParameterType($this->fullyQualifiedClassName, 'bulkSetItems', 'array', $this)
+            TestHelpers::getParameterType($this->fullyQualifiedClassName, '__construct', 'array', $this)
         );
     }
 
-    public function testBulkSetItemsKeyError(): void
+    public function testConstructorArrayKeyError(): void
     {
-        $secondPermittedClassObject = TestHelpers::generateAnonClassObject();
+        $secondPermittedClassObject = TestHelpers::newEmptyClassObject();
 
         $array = [
             'a' => $this->permittedClassObject,
@@ -149,10 +155,10 @@ final class StringToClassArrayTest extends TestCase
 
         $this::expectException(\InvalidArgumentException::class);
 
-        $this->extendsTypedArray->bulkSetItems($array);
+        $this->newExtendingClassObject($this->permittedClass, $array);
     }
 
-    public function testBulkSetItemsClassError(): void
+    public function testConstructorArrayClassError(): void
     {
         $array = [
             'a' => $this->permittedClassObject,
@@ -161,12 +167,12 @@ final class StringToClassArrayTest extends TestCase
 
         $this::expectException(\InvalidArgumentException::class);
 
-        $this->extendsTypedArray->bulkSetItems($array);
+        $this->newExtendingClassObject($this->permittedClass, $array);
     }
 
-    public function testBulkSetItemsValueError(): void
+    public function testConstructorArrayValueError(): void
     {
-        $secondPermittedClassObject = TestHelpers::generateAnonClassObject();
+        $secondPermittedClassObject = TestHelpers::newEmptyClassObject();
 
         $array = [
             'a' => $this->permittedClassObject,
@@ -177,7 +183,7 @@ final class StringToClassArrayTest extends TestCase
 
         $this::expectException(\InvalidArgumentException::class);
 
-        $this->extendsTypedArray->bulkSetItems($array);
+        $this->newExtendingClassObject($this->permittedClass, $array);
     }
 
     //unsetItem:
@@ -186,7 +192,7 @@ final class StringToClassArrayTest extends TestCase
     {
         $this->extendsTypedArray->setItem('a', $this->permittedClassObject);
 
-        $secondPermittedClassObject = TestHelpers::generateAnonClassObject();
+        $secondPermittedClassObject = TestHelpers::newEmptyClassObject();
 
         $this->extendsTypedArray->setItem('b', $secondPermittedClassObject);
 
@@ -284,7 +290,7 @@ final class StringToClassArrayTest extends TestCase
     {
         $this->extendsTypedArray->setItem('a', $this->permittedClassObject);
 
-        $secondPermittedClassObject = TestHelpers::generateAnonClassObject();
+        $secondPermittedClassObject = TestHelpers::newEmptyClassObject();
 
         $this->extendsTypedArray->setItem('b', $secondPermittedClassObject);
 

--- a/tests/StringToValueArrays/StringToClassArrayTest.php
+++ b/tests/StringToValueArrays/StringToClassArrayTest.php
@@ -117,7 +117,7 @@ final class StringToClassArrayTest extends TestCase
         );
     }
 
-    //bulkSetItemson construct:
+    //bulkSetItems on construct:
     //no need to test for numeric string key casting, as numeric strings will have already been int cast in the array
     public function testConstructorBulkSetItems(): void
     {

--- a/tests/StringToValueArrays/StringToIntArrayTest.php
+++ b/tests/StringToValueArrays/StringToIntArrayTest.php
@@ -100,7 +100,7 @@ final class StringToIntArrayTest extends TestCase
         new StringToIntArray($array);
     }
 
-    public function testBulkSetItemsValueError(): void
+    public function testConstructorArrayValueError(): void
     {
         $array = [
             'a' => 0,

--- a/tests/StringToValueArrays/StringToIntArrayTest.php
+++ b/tests/StringToValueArrays/StringToIntArrayTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection PhpExpressionResultUnusedInspection */
 
 declare(strict_types = 1);
 
@@ -63,32 +63,32 @@ final class StringToIntArrayTest extends TestCase
         );
     }
 
-    //bulkSetItems:
+    //bulkSetItems on construct:
     //no need to test for numeric string key casting, as numeric strings will have already been int cast in the array
-    public function testBulkSetItems(): void
+    public function testConstructorBulkSetItems(): void
     {
         $array = [
             'a' => 0,
             'b' => 1
         ];
 
-        $this->array->bulkSetItems($array);
+        $newTypedArray = new StringToIntArray($array);
 
         $this::assertSame(
             $array,
-            $this->array->getItems()
+            $newTypedArray->getItems()
         );
     }
 
-    public function testBulkSetItemsParamIsTypeArray(): void
+    public function testArrayParamIsTypeArray(): void
     {
         $this::assertSame(
             'array',
-            TestHelpers::getParameterType($this->fullyQualifiedClassName, 'bulkSetItems', 'array', $this)
+            TestHelpers::getParameterType($this->fullyQualifiedClassName, '__construct', 'array', $this)
         );
     }
 
-    public function testBulkSetItemsKeyError(): void
+    public function testConstructorArrayKeyError(): void
     {
         $array = [
             'a' => 0,
@@ -97,7 +97,7 @@ final class StringToIntArrayTest extends TestCase
 
         $this::expectException(\InvalidArgumentException::class);
 
-        $this->array->bulkSetItems($array);
+        new StringToIntArray($array);
     }
 
     public function testBulkSetItemsValueError(): void
@@ -111,7 +111,7 @@ final class StringToIntArrayTest extends TestCase
 
         $this::expectException(\InvalidArgumentException::class);
 
-        $this->array->bulkSetItems($array);
+        new StringToIntArray($array);
     }
 
     //unsetItem:

--- a/tests/StringToValueArrays/StringToStringArrayTest.php
+++ b/tests/StringToValueArrays/StringToStringArrayTest.php
@@ -100,7 +100,7 @@ final class StringToStringArrayTest extends TestCase
         new StringToStringArray($array);
     }
 
-     public function testBulkSetItemsValueError(): void
+     public function testConstructorArrayValueError(): void
     {
         $array = [
             'a' => 'a1',

--- a/tests/StringToValueArrays/StringToStringArrayTest.php
+++ b/tests/StringToValueArrays/StringToStringArrayTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection PhpExpressionResultUnusedInspection */
 
 declare(strict_types = 1);
 
@@ -63,32 +63,32 @@ final class StringToStringArrayTest extends TestCase
         );
     }
 
-    //bulkSetItems:
+    //bulkSetItems on construct:
     //no need to test for numeric string key casting, as numeric strings will have already been int cast in the array
-    public function testBulkSetItems(): void
+    public function testConstructorBulkSetItems(): void
     {
         $array = [
             'a' => 'a1',
             'b' => 'b1'
         ];
 
-        $this->array->bulkSetItems($array);
+        $newTypedArray = new StringToStringArray($array);
 
         $this::assertSame(
             $array,
-            $this->array->getItems()
+            $newTypedArray->getItems()
         );
     }
 
-    public function testBulkSetItemsParamIsTypeArray(): void
+    public function testArrayParamIsTypeArray(): void
     {
         $this::assertSame(
             'array',
-            TestHelpers::getParameterType($this->fullyQualifiedClassName, 'bulkSetItems', 'array', $this)
+            TestHelpers::getParameterType($this->fullyQualifiedClassName, '__construct', 'array', $this)
         );
     }
 
-    public function testBulkSetItemsKeyError(): void
+    public function testConstructorArrayKeyError(): void
     {
         $array = [
             'a' => 'a1',
@@ -97,7 +97,7 @@ final class StringToStringArrayTest extends TestCase
 
         $this::expectException(\InvalidArgumentException::class);
 
-        $this->array->bulkSetItems($array);
+        new StringToStringArray($array);
     }
 
      public function testBulkSetItemsValueError(): void
@@ -111,7 +111,7 @@ final class StringToStringArrayTest extends TestCase
 
         $this::expectException(\InvalidArgumentException::class);
 
-        $this->array->bulkSetItems($array);
+        new StringToStringArray($array);
     }
 
     //unsetItem:

--- a/tests/TestHelpers.php
+++ b/tests/TestHelpers.php
@@ -77,7 +77,7 @@ class TestHelpers extends TestCase
         }
     }
 
-    public static function generateAnonClassObject(): object
+    public static function newEmptyClassObject(): object
     {
         return new class {};
     }


### PR DESCRIPTION
… be rare, and placed it into the constructor where it would be far more common